### PR TITLE
Better support for updating contexts

### DIFF
--- a/obvs/patchscope.py
+++ b/obvs/patchscope.py
@@ -119,6 +119,10 @@ class TargetContext(SourceContext):
         mapping_function: Callable[[torch.Tensor], torch.Tensor] | None = None,
         max_new_tokens: int = 10,
     ) -> TargetContext:
+        """
+        Construct a target context from the source context
+        """
+
         return TargetContext(
             prompt=source.prompt,
             position=source.position,

--- a/obvs/patchscope.py
+++ b/obvs/patchscope.py
@@ -63,9 +63,6 @@ class SourceContext:
                  layer: int = -1,
                  model_name: str = "gpt2",
                  device: str = "cuda" if torch.cuda.is_available() else "cpu"):
-        self._prompt = ""
-        self._text_prompt = ""
-        self._soft_prompt = None
         self.prompt = prompt
         self.position = position
         self.layer = layer
@@ -130,7 +127,6 @@ class TargetContext(SourceContext):
                  device: str = "cuda" if torch.cuda.is_available() else "cpu",
                  mapping_function = lambda x: x,
                  max_new_tokens: int = 10):
-        self._prompt = None
         self.prompt = prompt
         self.position = position
         self.layer = layer

--- a/obvs/patchscope.py
+++ b/obvs/patchscope.py
@@ -62,6 +62,9 @@ class SourceContext:
     # See https://florimond.dev/en/posts/2018/10/reconciling-dataclasses-and-properties-in-python
     @property
     def prompt(self) -> str | torch.Tensor:
+        """
+        The prompt
+        """
         return self._prompt
 
     @prompt.setter
@@ -73,11 +76,11 @@ class SourceContext:
         if value is None:
             value = "<|endoftext|>"
 
-        if self._is_soft_prompt(value) and value.dim() != 2:
+        if isinstance(value, torch.Tensor) and value.dim() != 2:
             raise ValueError(f"Soft prompt must have shape [pos, dmodel]. prompt.shape = {value.shape}")
 
         self._prompt = value
-        if self._is_soft_prompt(value):
+        if isinstance(value, torch.Tensor):
             self._text_prompt = " ".join("_" * value.shape[0])
             self._soft_prompt = value
         else:
@@ -97,11 +100,6 @@ class SourceContext:
         The soft prompt input or None
         """
         return self._soft_prompt
-
-    @staticmethod
-    def _is_soft_prompt(prompt) -> bool:
-        return isinstance(prompt, torch.Tensor)
-
 
 
 @dataclass

--- a/obvs/patchscope.py
+++ b/obvs/patchscope.py
@@ -147,13 +147,6 @@ class ModelLoader:
             logger.info(f"Loading NNsight LanguagModel: {model_name}")
             return LanguageModel(model_name, device_map=device)
 
-    @staticmethod
-    def generation_kwargs(model_name: str, max_new_tokens: int) -> dict:
-        if "mamba" not in model_name:
-            return {"max_new_tokens": max_new_tokens}
-        else:
-            return {"max_new_tokens": max_new_tokens}
-
 
 class Patchscope(PatchscopeBase):
     REMOTE: bool = False
@@ -172,11 +165,6 @@ class Patchscope(PatchscopeBase):
             self.target_model = self.source_model
         else:
             self.target_model = ModelLoader.load(self.target.model_name, device=self.target.device)
-
-        self.generation_kwargs = ModelLoader.generation_kwargs(
-            self.target.model_name,
-            self.target.max_new_tokens,
-        )
 
         self.tokenizer = self.source_model.tokenizer
         self.init_positions()
@@ -231,7 +219,7 @@ class Patchscope(PatchscopeBase):
         with self.target_model.generate(
             self.target.text_prompt,
             remote=self.REMOTE,
-            **self.generation_kwargs,
+            max_new_tokens=self.target.max_new_tokens,
         ) as _:
             if self.target.soft_prompt is not None:
                 # Not sure if this works with mamba and other models

--- a/obvs/patchscope.py
+++ b/obvs/patchscope.py
@@ -167,7 +167,6 @@ class Patchscope(PatchscopeBase):
             self.target_model = ModelLoader.load(self.target.model_name, device=self.target.device)
 
         self.tokenizer = self.source_model.tokenizer
-        self.init_positions()
 
         self.MODEL_SOURCE, self.LAYER_SOURCE = self.get_model_specifics(self.source.model_name)
         self.MODEL_TARGET, self.LAYER_TARGET = self.get_model_specifics(self.target.model_name)
@@ -198,7 +197,7 @@ class Patchscope(PatchscopeBase):
         """
         return getattr(getattr(self.source_model, self.MODEL_SOURCE), self.LAYER_SOURCE)[
             self.source.layer
-        ].output[0][:, self.source.position, :]
+        ].output[0][:, self._source_position, :]
 
     def map(self) -> None:
         """
@@ -231,7 +230,7 @@ class Patchscope(PatchscopeBase):
         (
             getattr(getattr(self.target_model, self.MODEL_TARGET), self.LAYER_TARGET)[
                 self.target.layer
-            ].output[0][:, self.target.position, :]
+            ].output[0][:, self._target_position, :]
         ) = self._mapped_hidden_state
 
         self._target_outputs.append(self.target_model.lm_head.output[0].save())

--- a/obvs/patchscope_base.py
+++ b/obvs/patchscope_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Sequence
 
 import torch
 
@@ -38,6 +39,18 @@ class PatchscopeBase(ABC):
         pass
 
     @property
+    def _source_position(self) -> Sequence[int]:
+        return (self.source.position
+                if self.source.position is not None
+                else range(len(self.source_token_ids)))
+
+    @property
+    def _target_position(self) -> Sequence[int]:
+        return (self.target.position
+                if self.target.position is not None
+                else range(len(self.target_token_ids)))
+
+    @property
     def source_token_ids(self) -> list[int]:
         """
         Return the source tokens
@@ -64,14 +77,6 @@ class PatchscopeBase(ABC):
         Return the input to the target model
         """
         return [self.tokenizer.decode(token) for token in self.target_token_ids]
-
-    def init_positions(self, force: bool=False) -> None:
-        if self.source.position is None or force:
-            # If no position is specified, take them all
-            self.source.position = range(len(self.source_token_ids))
-
-        if self.target.position is None or force:
-            self.target.position = range(len(self.target_token_ids))
 
     def top_k_tokens(self, k: int=10) -> list[str]:
         """

--- a/tests/test_patchscopes.py
+++ b/tests/test_patchscopes.py
@@ -58,9 +58,6 @@ class TestPatchscope:
         assert patchscope.source_model
         assert patchscope.target_model
 
-        assert patchscope.source.position == range(len(patchscope.tokenizer.encode("source")))
-        assert patchscope.target.position == range(len(patchscope.tokenizer.encode("target")))
-
         assert patchscope.source.layer == -1
         assert patchscope.target.layer == -1
 
@@ -98,7 +95,6 @@ class TestPatchscope:
 
         # This will set position to all tokens
         patchscope.source.position = None
-        patchscope.init_positions()
 
         patchscope.source.layer = 0
         patchscope.source_forward_pass()
@@ -113,7 +109,6 @@ class TestPatchscope:
         )  # Embedding dimension
 
         patchscope.source.prompt = "a dog is a dog"
-        patchscope.init_positions(force=True)
         patchscope.source_forward_pass()
         assert patchscope._source_hidden_state.value.shape[1] == len(
             patchscope.source_tokens,

--- a/tests/test_patchscopes_high_level.py
+++ b/tests/test_patchscopes_high_level.py
@@ -123,10 +123,6 @@ class TestPatchscope:
         patchscope.source.prompt = "a dog is a dog. a rat is a rat. a cat"
         patchscope.target.prompt = patchscope.source.prompt
         patchscope.target.max_new_tokens = 4
-        patchscope.generation_kwargs = ModelLoader.generation_kwargs(
-            patchscope.target.model_name,
-            4,
-        )
 
         patchscope.run()
 
@@ -143,10 +139,6 @@ class TestPatchscope:
         patchscope.target.position = None
         patchscope.init_positions()
         patchscope.target.max_new_tokens = 4
-        patchscope.generation_kwargs = ModelLoader.generation_kwargs(
-            patchscope.target.model_name,
-            4,
-        )
 
         patchscope.source.layer = 3
         patchscope.target.layer = 3
@@ -166,10 +158,6 @@ class TestPatchscope:
         patchscope.source.position = -1
         patchscope.target.position = -1
         patchscope.target.max_new_tokens = 4
-        patchscope.generation_kwargs = ModelLoader.generation_kwargs(
-            patchscope.target.model_name,
-            4,
-        )
 
         patchscope.source.layer = 3
         patchscope.target.layer = 3
@@ -214,10 +202,6 @@ class TestPatchscope:
             "bat is bat; 135 is 135; hello is hello; black is black; shoe is shoe; x is"
         )
         patchscope.target.max_new_tokens = 4
-        patchscope.generation_kwargs = ModelLoader.generation_kwargs(
-            patchscope.target.model_name,
-            4,
-        )
 
         # Take the final token from the source
         patchscope.source.position = -1
@@ -247,10 +231,6 @@ class TestPatchscope:
             "bat is bat; 135 is 135; hello is hello; black is black; shoe is shoe; x is"
         )
         patchscope.target.max_new_tokens = 4
-        patchscope.generation_kwargs = ModelLoader.generation_kwargs(
-            patchscope.target.model_name,
-            4,
-        )
 
         # Take the final token from the source
         patchscope.source.position = -1
@@ -278,10 +258,7 @@ class TestPatchscope:
         patchscope.target.position = None
         patchscope.init_positions()
         patchscope.target.max_new_tokens = 2
-        patchscope.generation_kwargs = ModelLoader.generation_kwargs(
-            patchscope.target.model_name,
-            2,
-        )
+
         values = list(patchscope.over(range(2), range(4)))
         # Its a layer x layer list
         assert len(values) == 8

--- a/tests/test_patchscopes_high_level.py
+++ b/tests/test_patchscopes_high_level.py
@@ -19,7 +19,6 @@ class TestPatchscope:
         # This configuration will set it to take all tokens
         patchscope.source.position = None
         patchscope.target.position = None
-        patchscope.init_positions()
 
         patchscope.run()
         output = patchscope._target_outputs[0].value.argmax(dim=-1)[-1].tolist()
@@ -36,7 +35,6 @@ class TestPatchscope:
         patchscope.source.prompt = "a dog is a dog. a cat is a"
         patchscope.target.prompt = "a dog is a dog. a rat is a"
         patchscope.target.max_new_tokens = 1
-        patchscope.init_positions()
 
         for i in range(patchscope.n_layers):
             patchscope.source.level = i
@@ -137,7 +135,6 @@ class TestPatchscope:
         patchscope.target.prompt = "a dog is a dog. a bat is a bat. a rat"
         patchscope.source.position = None
         patchscope.target.position = None
-        patchscope.init_positions()
         patchscope.target.max_new_tokens = 4
 
         patchscope.source.layer = 3
@@ -182,7 +179,6 @@ class TestPatchscope:
 
         patchscope.source.layer = -1
         patchscope.target.layer = -1
-        patchscope.init_positions()
 
         patchscope.run()
 
@@ -256,7 +252,6 @@ class TestPatchscope:
         patchscope.target.prompt = "a dog is a dog. a bat is a bat. a rat"
         patchscope.source.position = None
         patchscope.target.position = None
-        patchscope.init_positions()
         patchscope.target.max_new_tokens = 2
 
         values = list(patchscope.over(range(2), range(4)))


### PR DESCRIPTION
### Notes
obvs doesn't support updating context very well:
* When updating `prompt` to a soft prompt, we don't validate the dimensions of the soft prompt.
* When updating `max_new_tokens`, user needs to also call `patchscope.generation_kwargs = ModelLoader.generation_kwargs(...)`.
* When setting `position = None`, user needs to call `patchscope.init_positions()`.

This PR fixes these issues.

### Issue
https://app.asana.com/0/1206344788073276/1206914748769697

### Testing
`pytest` passed.