### PR TITLE
Add repository and documentation metadata to poetry (& PyPI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ authors = ["Jamie Coombes <jamie@example.com>"]
 license = "MIT"
 packages = [{ include = "obvs" }]
 readme = "README.md"
+repository = "https://github.com/obvslib/obvs"
+documentation = "https://obvs.readthedocs.io"
 
 [tool.poetry.dependencies]
 python = "^3.10.0"


### PR DESCRIPTION
### Notes
@jcoombes noted that our PyPI project does not link back to the GitHub repo: https://snyk.io/advisor/python/obvs . This PR should fix it.

Documentation: https://python-poetry.org/docs/pyproject/#repository

Testing: See https://test.pypi.org/project/obvs/